### PR TITLE
v1.21.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "account",
-  "version": "1.21.3",
+  "version": "1.21.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "account",
-      "version": "1.21.3",
+      "version": "1.21.4",
       "license": "GPL",
       "dependencies": {
         "@chenfengyuan/vue-qrcode": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "account",
-  "version": "1.21.3",
+  "version": "1.21.4",
   "description": "Edge Account Portal",
   "private": true,
   "license": "GPL",

--- a/src/views/dashboard/Index.vue
+++ b/src/views/dashboard/Index.vue
@@ -5,45 +5,19 @@
 <script>
 import { mapState } from 'vuex'
 
-const awaitRedirectTimeout = 5000
-
 export default {
   name: 'Index',
   title() {
     return 'Edge Account Portal » Index'
   },
-  data() {
-    return {
-      t: null
-    }
-  },
   computed: {
     ...mapState(['account', 'progress'])
   },
-  methods: {
-    gotoDefault() {
-      clearTimeout(this.t)
-      this.$router.replace({ name: 'CdnIntegrations' })
-    },
-    gotoGettingStarted() {
-      clearTimeout(this.t)
-      this.$router.replace({ name: 'Getting Started' })
-    }
-  },
-  watch: {
-    account(a) {
-      if (a && a.isSetup) this.gotoDefault()
-    },
-    progress(p) {
-      if (!p) return
-      if (p.all) this.gotoDefault()
-      else this.gotoGettingStarted()
-    }
-  },
   mounted() {
-    this.t = setTimeout(() => {
-      this.gotoDefault()
-    }, awaitRedirectTimeout)
+    // If user has finished account setup, redirect to cdn, otherwise, to getting started.
+    const isSetup = this.account?.isSetup || this.progress?.all
+    if (isSetup) this.$router.replace({ name: 'Content Delivery' })
+    else this.$router.replace({ name: 'Getting Started' })
   }
 }
 </script>


### PR DESCRIPTION
This PR reverts the fix implemented in [commit 60ddfc3](https://github.com/edge/account/commit/60ddfc3efe84446700a7e496d5c33c2b2edca508), which inadvertently introduced inconsistent behavior—pages would either function as intended or incorrectly redirect. Alongside the revert, this PR applies the appropriate solution by incorporating null checks (e.g., `this.thing?.subthing`) to prevent the issue from occurring.